### PR TITLE
feat: Setup admin dashboard access and initial frontend structure

### DIFF
--- a/frontend/src/components/header.html
+++ b/frontend/src/components/header.html
@@ -50,6 +50,14 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
           </svg>
         </a>
+
+        <!-- LIEN ADMIN (Desktop) - Placeholder -->
+        <a href="/src/pages/admin/admin.html" id="admin-link-desktop" aria-label="Administration" class="p-2 text-wud-secondary hover:text-wud-primary hover:bg-wud-light rounded-full transition-all hidden">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </a>
         
         <!-- Wishlist -->
         <a href="/src/pages/wishlist.html" aria-label="Liste de souhaits" class="relative p-2 text-wud-secondary hover:text-wud-primary hover:bg-wud-light rounded-full transition-all">
@@ -94,6 +102,14 @@
     <a href="/src/pages/blog.html" class="block py-2 px-4 text-sm text-gray-700 hover:bg-gray-100 hover:text-wud-primary">Blog</a>
     <hr class="my-1">
     <a href="/src/pages/login.html" id="mobile-user-account-link" class="block py-2 px-4 text-sm text-gray-700 hover:bg-gray-100 hover:text-wud-primary">Mon Compte</a>
+    <!-- LIEN ADMIN (Mobile) - Placeholder -->
+    <a href="/src/pages/admin/admin.html" id="admin-link-mobile" class="block py-2 px-4 text-sm text-gray-700 hover:bg-gray-100 hover:text-wud-primary hidden">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+         <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+      Administration
+    </a>
     <a href="/src/pages/wishlist.html" class="block py-2 px-4 text-sm text-gray-700 hover:bg-gray-100 hover:text-wud-primary">
       Liste de souhaits <span id="mobile-wishlist-count-badge" class="ml-1 bg-wud-accent text-white text-xs rounded-full h-4 w-4 inline-flex items-center justify-center hidden">0</span>
     </a>

--- a/frontend/src/js/admin/uiAdmin.js
+++ b/frontend/src/js/admin/uiAdmin.js
@@ -1,0 +1,25 @@
+// frontend/src/js/admin/uiAdmin.js
+import { getCurrentUser } from '../auth.js'; // Supposant que getCurrentUser retourne l'utilisateur ou null
+
+export function setupAdminUI() {
+    const user = getCurrentUser(); // Récupère les informations de l'utilisateur (doit inclure le rôle)
+
+    const adminLinkDesktop = document.getElementById('admin-link-desktop');
+    const adminLinkMobile = document.getElementById('admin-link-mobile');
+
+    if (user && user.role === 'admin') {
+        if (adminLinkDesktop) {
+            adminLinkDesktop.classList.remove('hidden');
+        }
+        if (adminLinkMobile) {
+            adminLinkMobile.classList.remove('hidden');
+        }
+    } else {
+        if (adminLinkDesktop) {
+            adminLinkDesktop.classList.add('hidden');
+        }
+        if (adminLinkMobile) {
+            adminLinkMobile.classList.add('hidden');
+        }
+    }
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,6 +11,7 @@ import { initCheckoutPage } from './js/checkoutPage.js';
 import { initOrdersPage } from './js/ordersPage.js';
 import { initBlogPage } from './js/blogPage.js'; // Ajouté
 import { initBlogPostPage } from './js/blogPostPage.js'; // Ajouté
+import { setupAdminUI } from './js/admin/uiAdmin.js'; // Import setupAdminUI
 
 async function loadComponent(componentPath, placeholderId, callback) {
   const placeholder = document.getElementById(placeholderId);
@@ -38,7 +39,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   await loadComponent('/src/components/header.html', 'header-placeholder', () => {
     initializeHeaderInteractions();
-    checkAuthState();
+    checkAuthState(); // This will eventually trigger 'authChange'
+    setupAdminUI(); // Call it once after header is loaded and auth state is initially checked
     initializeCart();
     initializeWishlist();
   });
@@ -236,6 +238,7 @@ document.addEventListener('authChange', (event) => {
     console.log('Auth state changed globally:', event.detail);
     if (typeof updateCartOnAuthChange === 'function') updateCartOnAuthChange(event.detail);
     if (typeof updateWishlistOnAuthChange === 'function') updateWishlistOnAuthChange(event.detail);
+    if (typeof setupAdminUI === 'function') setupAdminUI(); // Update admin UI on auth change
 });
 
 window.WudApp = {

--- a/routes/product.routes.js
+++ b/routes/product.routes.js
@@ -35,7 +35,6 @@ router.put('/:id', protect, admin, updateProduct);
 
 // Pour supprimer un produit (route générique, garder pour compatibilité)
 router.delete('/:id', protect, admin, deleteProduct);
-router.get('/admin/:id', protect, admin, getProductByIdAdmin);
 
 
 module.exports = router;


### PR DESCRIPTION
- Validated existing backend CRUD functionalities for admin panel (Users, Products, Categories, Orders, Custom Requests).
- Provided JSON examples for testing admin API endpoints.
- Added 'Admin' link dynamically to the main header based on user role.
  - Created uiAdmin.js for this logic.
  - Updated header.html with placeholders for admin links.
  - Integrated setupAdminUI into main.js initialization and auth change events.
- Cleaned up a duplicate route in product.routes.js.

This commit lays the groundwork for building out the admin panel's frontend components by ensuring admins can access the admin area and that the basic page structure is recognized.